### PR TITLE
Fix preview auth error handling and feed generation robustness

### DIFF
--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -32,28 +32,38 @@ export async function GET(req: Request) {
 
   await Promise.all(
     articles.map(async (article) => {
-      const url = String(
-        new URL(`/articles/${article._sys.filename}`, req.url)
-      );
-      const html = await (await fetch(url)).text();
-      const $ = load(html);
+      try {
+        const url = String(
+          new URL(`/articles/${article._sys.filename}`, req.url)
+        );
+        const response = await fetch(url);
 
-      const publicUrl = `${siteUrl}/articles/${article._sys.filename}`;
-      const articleDom = $('article').first();
-      const title = article.title;
-      const date = article.date;
-      const content =
-        articleDom.find('[data-mdx-content]').first().html() ?? undefined;
+        if (!response.ok) {
+          return;
+        }
 
-      feed.addItem({
-        title,
-        id: publicUrl,
-        link: publicUrl,
-        content,
-        author: [author],
-        contributor: [author],
-        date: new Date(date),
-      });
+        const html = await response.text();
+        const $ = load(html);
+
+        const publicUrl = `${siteUrl}/articles/${article._sys.filename}`;
+        const articleDom = $('article').first();
+        const title = article.title;
+        const date = article.date;
+        const content =
+          articleDom.find('[data-mdx-content]').first().html() ?? '';
+
+        feed.addItem({
+          title,
+          id: publicUrl,
+          link: publicUrl,
+          content,
+          author: [author],
+          contributor: [author],
+          date: new Date(date),
+        });
+      } catch (_error) {
+        // Continue processing other articles even if one fails
+      }
     })
   );
 


### PR DESCRIPTION
## Summary
- Improved error handling in user authorization for preview mode
- Added validation to prevent open redirect vulnerabilities in preview slug
- Enhanced robustness of feed generation by handling fetch failures gracefully

## Changes

### Preview API
- Wrapped fetch call in `isUserAuthorized` with try-catch to handle network or other errors
- Return `null` on fetch failure or non-ok response to avoid unhandled exceptions
- Added validation for `slug` parameter in preview GET handler to reject invalid or potentially unsafe slugs (e.g., containing protocol, domain, or directory traversal)

### Feed Generation
- Wrapped article fetch in try-catch to prevent one failing article from breaking the entire feed generation
- Skipped adding feed items if article fetch response is not ok
- Ensured empty string fallback for article content to avoid undefined values

## Test plan
- [x] Verify preview mode authorization returns null on invalid token or network failure
- [x] Confirm invalid slugs are rejected with 400 status
- [x] Check feed generation completes successfully even if some article fetches fail
- [x] Validate feed items are correctly added for successfully fetched articles

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/c2d18baa-6ae8-49f8-9382-f2f21227484d